### PR TITLE
Convert to subtests

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,10 +57,10 @@ func main() {
 		// to allow CSRF protection to work.
 		csrf.Secure(false)
 	}
-	CSRFMiddleware := csrf.Protect([]byte(conf.CSRFSecret))
+	csrfMiddleware := csrf.Protect([]byte(conf.CSRFSecret))
 
 	log.Printf("Listening on port %v", conf.Port)
-	log.Fatal(http.ListenAndServe(":"+conf.Port, CSRFMiddleware(r)))
+	log.Fatal(http.ListenAndServe(":"+conf.Port, csrfMiddleware(r)))
 }
 
 //


### PR DESCRIPTION
Subtests [1] provide better clarity than blocks in some situations, and
also have some really nicely nested output with `go test -v`. Convert
over a few test cases to see how they look.

[1] https://blog.golang.org/subtests