### PR TITLE
Build a Docker image and add Kubernetes resources

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# This style of ignore creates a whitelist instead of a blacklist so that we
+# don't have to continually add new files here so that Docker ignores them.
+*
+!/*.go
+!/*.sql
+!/layouts/
+!/public/
+!/vendor/
+!/views/
+
+# Send all Go files except test files which we don't need for the build.
+*_test.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,26 @@ script:
   - go test -v &&
     go vet &&
     golint -set_exit_status &&
-    scripts/check_gofmt.sh
+    scripts/check_gofmt.sh &&
+    docker build -t "$DOCKER_REPO" . &&
+    scripts/push_docker.sh
 
 notifications:
   email:
     on_success: never
+
+# Create an encrypted variable similar to the one below using:
+#
+#     travis encrypt --org DOCKER_PASSWORD=<password>
+#
+# You'll need the `travis` gem which is correctly configured. For more
+# information:
+#
+#     https://docs.travis-ci.com/user/environment-variables/#Defining-encrypted-variables-in-.travis.yml
+#
+env:
+  global:
+    - DOCKER_REPO="brandur/passages-signup"
+    - DOCKER_USERNAME=brandur
+    # DOCKER_PASSWORD
+    - secure: "bnjXDAtqqdwriXtzuyxT5/V6nZqFDyNdZR2EqawA5gcNhmUxIrGTiClwKzG2oiaxbYUj/uRzRMOharhXYi+eTMSdq7FKOd5hS6aRizodQ+90gBRqnfKa36NTguWprFFj4m9TnZU+djVOv1/3N34Qxjr4B54HEz8VFNayapaPfurcytfQfBGV1dAODU46nGkn2vFDQHVm7b8v3ypI8JNG7AwA4XBTrdu+I3hBKrdbCNtvRC9rhJdMTf1JMBzVwwHHX3zsA3N+KtDtXqs137vm3+GEinxpDNiER3j8E0HsLZjZEzfSObepXHlax9EcA24tQDMCoqhXC/2s/c7PhDLU4Rm+tSYF3V66TwF+ULUclCDLJXDfPiJLbK2bDqv0Bbh0944aHVa2+ac1bFKF6+S4Ruqih0zvV7LyC7cn3vwFKaPiHR4eUa7Sf1e9fqBzHkSXg3zm4ob/xr6D7dLnTjWxWOQVrfK2rMOf4Iymh1HdNWSWNbELoV23yP0kXotWc5h5m9lhE9oW2/cPwwvZpaxV/eV5/boRe4+WQpRrYBoL9QYLorOipftjm4l9hi0aKo2JuD+MZ1Ug0bQZ8NBzFoet1mzFV/RsNHxM6RkbkG3+A8sH8YHjGfiP7NBChuI79ozUJ9WAev6ID6sFiUWIMBuw1XNmuE5xfYZTTMixlPyTVF4="

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# -*- mode: dockerfile -*-
+#
+# A multi-stage Dockerfile that builds a Linux target then creates a small
+# final image for deployment.
+
+#
+# STAGE 1
+#
+# Build from source.
+#
+
+FROM golang:alpine AS builder
+
+RUN go version
+
+# The Go Alpine image gets an automatic `$GOPATH` of `/go`, which we know in
+# advance and are going to take advantage of here.
+ENV BUILD_DIR=/go/src/passages-signup
+
+# Add source code. Note that `.dockerignore` will take care of excluding the
+# vast majority of files in the current directory and just bring in the couple
+# core files that we need.
+ADD ./ $BUILD_DIR/
+
+# Build the project.
+WORKDIR $BUILD_DIR
+RUN go build -o passages-signup .
+
+#
+# STAGE 2
+#
+# Use a tiny base image (alpine) and copy in the release target. This produces
+# a very small output image for deployment.
+#
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+
+ENV BUILD_DIR=/go/src/passages-signup
+
+COPY --from=builder $BUILD_DIR/*.sql /
+COPY --from=builder $BUILD_DIR/passages-signup /
+COPY --from=builder $BUILD_DIR/layouts/ /layouts/
+COPY --from=builder $BUILD_DIR/views/ /views/
+
+ENV PORT 8082
+ENTRYPOINT ["/passages-signup"]

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,46 @@
+# Kubernetes setup
+
+## Docker image build
+
+Make sure a Docker image is built:
+
+    docker build -t brandur/passages-signup .
+
+(Without a tag like `brandur/passages-signup:tag` specified, this will build
+`brandur/passages-signup:latest`.)
+
+Make sure Docker Hub login is active:
+
+    docker login
+
+Push the image:
+
+    docker push brandur/passages-signup
+
+## Kubernetes configuration
+
+Make sure a Kubernetes configuration file is available (`$KUBECONFIG` should be
+set and the file it's pointing to should exist).
+
+    kubectl apply -f kubernetes/
+    kubectl apply -f kubernetes/passages-signup.yaml
+
+### Digital Ocean
+
+Install `doctl`:
+
+    brew install doctl
+    brew auth init
+
+Creating a certificate that automatically renews with Let's Encrypt:
+
+    doctl compute certificate create --name "passages-signup-k8s-brandur-org" --dns-names "passages-signup.k8s.brandur.org" --type lets_encrypt
+
+Creating secrets:
+
+    kubectl create secret generic database-url --from-literal=DATABASE_URL=postgres://localhost/passages-signup
+    kubectl create secret generic mailgun-api-key --from-literal=MAILGUN_API_KEY=key-xxx
+
+<!--
+# vim: set tw=79:
+-->

--- a/kubernetes/passages-signup-svc.yaml
+++ b/kubernetes/passages-signup-svc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: passages-signup
+  labels:
+    name: passages-signup
+spec:
+  ports:
+  - port: 8082
+    protocol: TCP
+  selector:
+    name: passages-signup
+  type: NodePort

--- a/kubernetes/passages-signup.yaml
+++ b/kubernetes/passages-signup.yaml
@@ -1,0 +1,42 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: passages-signup
+  labels:
+    app: passages-signup
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: passages-signup
+    spec:
+      containers:
+      - name: podcore
+        image: brandur/passages-signup:latest
+        command: ["/passages-signup"]
+        ports:
+        - containerPort: 8082
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: database-url
+              key: DATABASE_URL
+        - name: MAILGUN_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: mailgun-api-key
+              key: MAILGUN_API_KEY
+        - name: PASSAGES_ENV
+          value: "production"
+        - name: PORT
+          value: "8082"
+        - name: PUBLIC_URL
+          value: "https://example.com"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 5

--- a/kubernetes/unified-ingress.yaml
+++ b/kubernetes/unified-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: unified-ingress
+  annotations:
+    # service.beta.kubernetes.io/do-loadbalancer-protocol: "http"
+    # service.beta.kubernetes.io/do-loadbalancer-algorithm: "round_robin"
+    # service.beta.kubernetes.io/do-loadbalancer-tls-ports: "443"
+spec:
+  type: LoadBalancer
+  selector:
+    app: passages-signup
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8082
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 8082

--- a/scripts/push_docker.sh
+++ b/scripts/push_docker.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Pushes a built Docker image to Docker Hub.
+#
+# Cargo culted from the Travis documentation:
+#
+#     https://docs.travis-ci.com/user/docker/
+
+docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
+docker push "$DOCKER_REPO"


### PR DESCRIPTION
Builds a docker image for the repository to be pushed to Docker Hub at
`brandur/passages-signup`.

Adds various Kubernetes resources (preliminary ones at least) for use
with a Digital Ocean Kubernetes cluster.