### PR TITLE
Add Terraform job to build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
 
     env:
       GOPATH: "/home/runner/work/passages-signup/go"
@@ -92,3 +92,42 @@ jobs:
       - name: "Check: Golint"
         run: "$GOPATH/bin/golint -set_exit_status"
 
+  terraform:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@master
+
+      - name: "Copy .tfvars"
+        run: cp terraform/terraform.tfvars.sample terraform/terraform.tfvars
+
+      - name: "Terraform Format"
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: "latest"
+          tf_actions_subcommand: "fmt"
+          tf_actions_working_dir: "./terraform"
+
+      - name: 'Terraform Init'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: "latest"
+          tf_actions_subcommand: "init"
+          tf_actions_working_dir: "./terraform"
+
+      - name: "Terraform Validate"
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: "latest"
+          tf_actions_subcommand: "validate"
+          tf_actions_working_dir: "./terraform"
+
+      # Requires working CloudFlare/Digital Ocean keys.
+      # - name: "Terraform Plan"
+      #   uses: hashicorp/terraform-github-actions@master
+      #   with:
+      #     tf_actions_version: "latest"
+      #     tf_actions_subcommand: "plan"
+      #     tf_actions_working_dir: "./terraform"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,12 +10,12 @@ variable "do_token" {}
 variable "mailgun_api_key" {}
 
 provider "cloudflare" {
-  email = "${var.cloudflare_email}"
-  token = "${var.cloudflare_token}"
+  email     = var.cloudflare_email
+  api_token = var.cloudflare_token
 }
 
 provider "digitalocean" {
-  token = "${var.do_token}"
+  token = var.do_token
 }
 
 #
@@ -194,36 +194,36 @@ data "digitalocean_domain" "do" {
 
 # A records that allow us to identify specific nodes for easy SSH/etc.
 resource "digitalocean_record" "passages_signup_0" {
-  domain = "${data.digitalocean_domain.do.name}"
+  domain = data.digitalocean_domain.do.name
   type   = "A"
   name   = "passages-signup-0"
   ttl    = 600
-  value  = "${digitalocean_droplet.passages_signup.ipv4_address}"
+  value  = digitalocean_droplet.passages_signup.ipv4_address
 }
 
 # An overloaded A/AAAA record for load balancing between nodes.
 resource "digitalocean_record" "passages_signup_round_robin_0" {
-  domain = "${data.digitalocean_domain.do.name}"
+  domain = data.digitalocean_domain.do.name
   type   = "A"
   name   = "passages-signup" # value the same for all round robin records
   ttl    = 600
-  value  = "${digitalocean_droplet.passages_signup.ipv4_address}"
+  value  = digitalocean_droplet.passages_signup.ipv4_address
 }
 
 # And the same for IPv6.
 resource "digitalocean_record" "passages_signup_ipv6_round_robin_0" {
-  domain = "${data.digitalocean_domain.do.name}"
+  domain = data.digitalocean_domain.do.name
   type   = "AAAA"
   name   = "passages-signup" # value the same for all round robin records
   ttl    = 600
-  value  = "${digitalocean_droplet.passages_signup.ipv6_address}"
+  value  = digitalocean_droplet.passages_signup.ipv6_address
 }
 
 # And a top level CNAME that points back to the round robin A/AAAA record.
 resource "cloudflare_record" "passages_signup" {
-  domain = "brandur.org"
-  name   = "passages-signup"
-  value  = "${digitalocean_record.passages_signup_round_robin_0.fqdn}"
-  type   = "CNAME"
-  ttl    = 1 # magic value 1 sets TTL to "automatic"
+  name    = "passages-signup"
+  value   = digitalocean_record.passages_signup_round_robin_0.fqdn
+  type    = "CNAME"
+  ttl     = 1 # magic value 1 sets TTL to "automatic"
+  zone_id = "brandur.org"
 }

--- a/terraform/terraform.tfvars.sample
+++ b/terraform/terraform.tfvars.sample
@@ -1,5 +1,5 @@
 cloudflare_email = ""
 cloudflare_token = ""
-database_url = ""
-do_token = ""
-mailgun_api_key = ""
+database_url     = ""
+do_token         = ""
+mailgun_api_key  = ""


### PR DESCRIPTION
Adds a Terraform job to format/init/validate/plan based on the
repository's Terraform recipe.

Also fix various problems that have been caused by backwards
incompatible updates to Cloudflare providers.