### PR TITLE
Max out the number of times we'll send a confirmation email

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           PGDATABASE: postgres
 
       - name: "Raise database schema"
-        run: psql passages-signup-test < schema.sql
+        run: psql passages-signup-test < sql/schema.sql
         env:
           PGHOST: localhost
           PGPORT: ${{ job.services.postgres.ports[5432] }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cd $GOPATH/src/github.com/brandur/passages-signup
 
 cp .envrc.sample .envrc
 createdb passages-signup
-psql passages-signup < schema.sql
+psql passages-signup < sql/schema.sql
 
 # open `.envrc`; edit MAILGUN_API_KEY
 
@@ -28,7 +28,7 @@ Open your browser to [localhost:5001](http://localhost:5001).
 ## Testing
 
     createdb passages-signup-test
-    psql passages-signup-test < schema.sql
+    psql passages-signup-test < sql/schema.sql
 
 ## Operations
 

--- a/deploy/heroku/README.md
+++ b/deploy/heroku/README.md
@@ -3,7 +3,7 @@
 Add a database:
 
     heroku addons:add heroku-postgresql:hobby-dev -r heroku-nanoglyph
-    heroku pg:psql -r heroku-nanoglyph < schema.sql
+    heroku pg:psql -r heroku-nanoglyph < sql/schema.sql
 
 Assign remotes:
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -86,6 +87,7 @@ func TestHandleConfirm(t *testing.T) {
 }
 
 func TestHandleShow_Nanoglyph(t *testing.T) {
+	conf.DatabaseURL = testhelpers.DatabaseURL
 	conf.NewsletterID = nanoglyphID
 
 	req := httptest.NewRequest("GET", "/", nil)
@@ -100,6 +102,7 @@ func TestHandleShow_Nanoglyph(t *testing.T) {
 }
 
 func TestHandleShow_Passages(t *testing.T) {
+	conf.DatabaseURL = testhelpers.DatabaseURL
 	conf.NewsletterID = passagesID
 
 	req := httptest.NewRequest("GET", "/", nil)
@@ -114,6 +117,8 @@ func TestHandleShow_Passages(t *testing.T) {
 }
 
 func TestHandleSubmit(t *testing.T) {
+	conf.DatabaseURL = testhelpers.DatabaseURL
+
 	testCases := []struct {
 		name       string
 		verb, path string
@@ -147,10 +152,12 @@ func TestHandleSubmit(t *testing.T) {
 			handleSubmit(w, req)
 
 			resp := w.Result()
-			assert.Equal(t, tc.wantStatus, resp.StatusCode)
 
-			_, err := ioutil.ReadAll(resp.Body)
+			body, err := ioutil.ReadAll(resp.Body)
 			assert.NoError(t, err)
+
+			assert.Equal(t, tc.wantStatus, resp.StatusCode,
+				fmt.Sprintf("Wrong status code (see above); body: %v", string(body)))
 		})
 	}
 }

--- a/sql/migrations/001_add_signup_num_attempts.sql
+++ b/sql/migrations/001_add_signup_num_attempts.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE signup
+ADD COLUMN num_attempts BIGINT NOT NULL DEFAULT 1;
+
+END;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -8,6 +8,7 @@ CREATE TABLE signup (
     completed_at TIMESTAMPTZ,
     email        VARCHAR(500) NOT NULL UNIQUE,
     last_sent_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    num_attempts BIGINT       NOT NULL DEFAULT 1,
     token        VARCHAR(100) NOT NULL UNIQUE
 );
 


### PR DESCRIPTION
Adds a maximum number of times we'll ever try to send a confirmation
email to a particular address. Not a hugely helpful mitigation, but
should curb potential abuse somewhat.