### PR TITLE
Add maintenance mode middleware to facilitate database migration

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,6 +1,7 @@
 export DATABASE_URL=postgres://localhost/passages-signup?sslmode=disable
 export ENABLE_RATE_LIMITER=true
 export MAILGUN_API_KEY=
+#export MAINTENANCE_MODE=true
 export NEWSLETTER_ID=passages
 export PASSAGES_ENV=testing
 export PORT=

--- a/middleware/maintenance_mode.go
+++ b/middleware/maintenance_mode.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/brandur/passages-signup/ptemplate"
+)
+
+// MaintenanceModeMiddleware sits above the server stack and allows the entire
+// service to be put into "maintenance mode" in which all API requests are
+// termined with a 503 Service Unavailable. This in turn allows us to carry out
+// critical maintenance on core infrastructure like the database without having
+// to worry about load or writes.
+type MaintenanceModeMiddleware struct {
+	maintenanceMode bool
+	renderer        *ptemplate.Renderer
+}
+
+func NewMaintenanceModeMiddleware(maintenanceMode bool, renderer *ptemplate.Renderer) *MaintenanceModeMiddleware {
+	return &MaintenanceModeMiddleware{
+		maintenanceMode: maintenanceMode,
+		renderer:        renderer,
+	}
+}
+
+func (m *MaintenanceModeMiddleware) Wrapper(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if m.maintenanceMode {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			if err := m.renderer.RenderTemplate(w, "views/maintenance", map[string]interface{}{}); err != nil {
+				logrus.Errorf("Error rendering maintenance mode: %v", err)
+				_, _ = w.Write([]byte(fmt.Sprintf("Error rendering maintenance mode: %v", err)))
+			}
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/middleware/maintenance_mode_test.go
+++ b/middleware/maintenance_mode_test.go
@@ -1,0 +1,76 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/brandur/passages-signup/newslettermeta"
+	"github.com/brandur/passages-signup/ptemplate"
+)
+
+func TestMaintenanceModeMiddlewareWrapper(t *testing.T) {
+	var (
+		handler  http.Handler
+		renderer *ptemplate.Renderer
+	)
+
+	setup := func(test func(*testing.T)) func(*testing.T) {
+		return func(t *testing.T) {
+			t.Helper()
+
+			handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("ok."))
+			})
+
+			var err error
+			renderer, err = ptemplate.NewRenderer(&ptemplate.RendererConfig{
+				DynamicReload:  true,
+				NewsletterMeta: newslettermeta.MustMetaFor("list.brandur.org", newslettermeta.PassagesID),
+				PublicURL:      "https://example.com",
+				Templates:      os.DirFS("../"),
+			})
+			require.NoError(t, err)
+
+			test(t)
+		}
+	}
+
+	t.Run("MaintenanceOn", setup(func(t *testing.T) { //nolint:thelper
+		handler = NewMaintenanceModeMiddleware(true, renderer).Wrapper(handler)
+
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+		handler.ServeHTTP(recorder, req)
+
+		res := recorder.Result() //nolint:bodyclose
+		require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
+
+		data := recorder.Body.Bytes()
+		require.Contains(t, string(data), "This application is currently in maintenance mode")
+	}))
+
+	t.Run("MaintenanceOff", setup(func(t *testing.T) { //nolint:thelper
+		handler = NewMaintenanceModeMiddleware(false, renderer).Wrapper(handler)
+
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+		handler.ServeHTTP(recorder, req)
+
+		requireStatusOrPrintBody(t, http.StatusOK, recorder)
+	}))
+}
+
+func requireStatusOrPrintBody(t *testing.T, expectedStatusCode int, recorder *httptest.ResponseRecorder) {
+	t.Helper()
+	//nolint:bodyclose
+	require.Equal(t, expectedStatusCode, recorder.Result().StatusCode,
+		"Expected status %v, but got %v; body was: %s",
+		expectedStatusCode,
+		recorder.Result().StatusCode,
+		recorder.Body.String(),
+	)
+}

--- a/views/maintenance.ace
+++ b/views/maintenance.ace
@@ -1,0 +1,3 @@
+= content main
+  #passages {{.NewsletterMeta.Name}}
+  | This application is currently in maintenance mode to facilitate non-standard operations. Please retry this request shortly.


### PR DESCRIPTION
I need to move these databases off of Heroku, so add a maintenance
mode middleware to help shut down the app while that's in progress.