### PR TITLE
Upgrade golangci-lint and fix new lint problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,12 +122,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Check: golangci-lint"
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52
+          version: v1.56
 
   image-push-docker-hub:
     if: github.ref == 'refs/heads/master'

--- a/command/signup_finisher_test.go
+++ b/command/signup_finisher_test.go
@@ -38,7 +38,7 @@ func TestSignupFinisher(t *testing.T) {
 			require.True(t, res.SignupFinished)
 			require.False(t, res.TokenNotFound)
 
-			require.Equal(t, 1, len(mailAPI.MembersAdded))
+			require.Len(t, mailAPI.MembersAdded, 1)
 			require.Equal(t, testhelpers.TestEmail, mailAPI.MembersAdded[0].Email)
 
 			//
@@ -53,7 +53,7 @@ func TestSignupFinisher(t *testing.T) {
 			require.True(t, res.SignupFinished)
 			require.False(t, res.TokenNotFound)
 
-			require.Equal(t, 2, len(mailAPI.MembersAdded))
+			require.Len(t, mailAPI.MembersAdded, 2)
 			require.Equal(t, testhelpers.TestEmail, mailAPI.MembersAdded[1].Email)
 		})
 	})
@@ -71,7 +71,7 @@ func TestSignupFinisher(t *testing.T) {
 			require.False(t, res.SignupFinished)
 			require.True(t, res.TokenNotFound)
 
-			require.Equal(t, 0, len(mailAPI.MembersAdded))
+			require.Empty(t, len(mailAPI.MembersAdded))
 		})
 	})
 }

--- a/command/signup_starter_test.go
+++ b/command/signup_starter_test.go
@@ -28,7 +28,7 @@ func TestSignupStarter(t *testing.T) {
 			require.False(t, res.MaxNumAttempts)
 			require.True(t, res.NewSignup)
 
-			require.Equal(t, 1, len(mailAPI.MessagesSent))
+			require.Len(t, mailAPI.MessagesSent, 1)
 			require.Equal(t, testhelpers.TestEmail, mailAPI.MessagesSent[0].Recipient)
 		})
 	})
@@ -56,7 +56,7 @@ func TestSignupStarter(t *testing.T) {
 			require.False(t, res.MaxNumAttempts)
 			require.False(t, res.NewSignup)
 
-			require.Equal(t, 1, len(mailAPI.MessagesSent))
+			require.Len(t, mailAPI.MessagesSent, 1)
 			require.Equal(t, testhelpers.TestEmail, mailAPI.MessagesSent[0].Recipient)
 		})
 	})
@@ -85,7 +85,7 @@ func TestSignupStarter(t *testing.T) {
 			require.False(t, res.MaxNumAttempts)
 			require.False(t, res.NewSignup)
 
-			require.Equal(t, 1, len(mailAPI.MessagesSent))
+			require.Len(t, mailAPI.MessagesSent, 1)
 			require.Equal(t, testhelpers.TestEmail, mailAPI.MessagesSent[0].Recipient)
 		})
 	})
@@ -113,7 +113,7 @@ func TestSignupStarter(t *testing.T) {
 			require.False(t, res.MaxNumAttempts)
 			require.False(t, res.NewSignup)
 
-			require.Equal(t, 0, len(mailAPI.MessagesSent))
+			require.Empty(t, mailAPI.MessagesSent)
 		})
 	})
 
@@ -142,7 +142,7 @@ func TestSignupStarter(t *testing.T) {
 			require.True(t, res.MaxNumAttempts)
 			require.False(t, res.NewSignup)
 
-			require.Equal(t, 0, len(mailAPI.MessagesSent))
+			require.Empty(t, mailAPI.MessagesSent)
 		})
 	})
 
@@ -172,7 +172,7 @@ func TestSignupStarter(t *testing.T) {
 			require.False(t, res.MaxNumAttempts)
 			require.False(t, res.NewSignup)
 
-			require.Equal(t, 1, len(mailAPI.MessagesSent))
+			require.Len(t, mailAPI.MessagesSent, 1)
 			require.Equal(t, testhelpers.TestEmail, mailAPI.MessagesSent[0].Recipient)
 		})
 	})
@@ -184,7 +184,7 @@ func TestSignupStarter(t *testing.T) {
 			mediator := signupStarter(mailAPI, "blah-not-an-email")
 
 			_, err := mediator.Run(ctx, tx)
-			require.Error(t, ErrInvalidEmail, err)
+			require.ErrorIs(t, err, ErrInvalidEmail)
 		})
 	})
 }

--- a/main.go
+++ b/main.go
@@ -428,7 +428,7 @@ func getRateLimiter() (*throttled.HTTPRateLimiter, error) {
 		return nil, xerrors.Errorf("error initializing rate limiter: %w", err)
 	}
 
-	deniedHandler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	deniedHandler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "Rate limit exceeded. Sorry about that -- please try again in a few seconds.", http.StatusTooManyRequests)
 	}))
 

--- a/middleware/maintenance_mode_test.go
+++ b/middleware/maintenance_mode_test.go
@@ -22,7 +22,7 @@ func TestMaintenanceModeMiddlewareWrapper(t *testing.T) {
 		return func(t *testing.T) {
 			t.Helper()
 
-			handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = w.Write([]byte("ok."))
 			})
 


### PR DESCRIPTION
Upgrade golangci-lint from v3 to v4 and v1.52 and v1.56, and fix the
various new lint problems that fell out.