### PR TITLE
Upgrade setup-go to v5 and checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           check-latest: true
           go-version: ${{ env.GO_VERSION }}
 
-      - name: 'Checkout'
-        uses: actions/checkout@v3
+      - name: "Checkout"
+        uses: actions/checkout@v4
 
       - name: Debug
         run: |
@@ -89,20 +89,20 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v3
+      - name: "Checkout"
+        uses: actions/checkout@v4
 
       - name: "GCP: Auth"
         uses: google-github-actions/auth@v0
         with:
-          credentials_json: '${{ secrets.GCP_CREDENTIALS_JSON }}'
+          credentials_json: "${{ secrets.GCP_CREDENTIALS_JSON }}"
 
       - name: "GCP: setup-gcloud"
         uses: google-github-actions/setup-gcloud@v0
         with:
           export_default_credentials: true
           project_id: passages-signup
-          version: 'latest'
+          version: "latest"
 
       - name: "GCP: gcloud info"
         run: gcloud info
@@ -136,8 +136,8 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: 'Checkout'
-        uses: actions/checkout@master
+      - name: "Checkout"
+        uses: actions/checkout@v4
 
       - name: "Docker Hub: Publish image"
         uses: elgohr/Publish-Docker-Github-Action@master
@@ -151,8 +151,8 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: 'Checkout'
-        uses: actions/checkout@master
+      - name: "Checkout"
+        uses: actions/checkout@v4
 
       - name: "Copy .tfvars"
         run: cp ./deploy/terraform/terraform.tfvars.sample ./deploy/terraform/terraform.tfvars
@@ -164,7 +164,7 @@ jobs:
           tf_actions_subcommand: "fmt"
           tf_actions_working_dir: "./deploy/terraform"
 
-      - name: 'Terraform: Init'
+      - name: "Terraform: Init"
         uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: "latest"


### PR DESCRIPTION
Periodic GitHub Actions maintenance. Upgrade setup-go from v3 to v5, and
checkout from v3 to v4. Also replace the use of `checkout@master` that
was there in a few places, which for whatever reason I originally did
this, is now presumably long since defunct.