### PR TITLE
Switch to Distroless base image + micellaneous cleanup + image build job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,17 @@ jobs:
       - name: "Check: Gofmt"
         run: scripts/check_gofmt.sh
 
+  container-image-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker build
+        run: docker build .
+
   deploy-google-cloud-run:
     if: github.ref == 'refs/heads/master'
     needs: build


### PR DESCRIPTION
Switch to Distroless as a base image instead of Alpine (decreases size
by about 6 MB) and do the some miscellaneous cleanup to simplify the
`Dockerfile` somewhat. Add CI job that builds a container image on
non-master branches.