### PR TITLE
Upgrade to Go 1.25 + use Go built-in CSRF protection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,7 +143,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.0.0
+          version: v2.4.0
 
   image-push-docker-hub:
     if: github.ref == 'refs/heads/master'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,10 +20,12 @@ linters:
     - lll
     - mnd
     - nlreturn
+    - noinlineerr
     - paralleltest
     - testpackage
     - varnamelen
     - wsl
+    - wsl_v5
 
   settings:
     forbidigo:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brandur/passages-signup
 
-go 1.24
+go 1.25.0
 
 toolchain go1.24.1
 

--- a/ptemplate/ptemplate.go
+++ b/ptemplate/ptemplate.go
@@ -26,6 +26,7 @@ type RendererConfig struct {
 
 type Renderer struct {
 	*RendererConfig
+
 	layoutPath string
 }
 


### PR DESCRIPTION
Upgrade to Go 1.25 and take advantage of its new built-in CSRF
protection [1] so we can move off my own hand rolled package that does
something similar.

[1] https://tip.golang.org/doc/go1.25#nethttppkgnethttp